### PR TITLE
Ng-repeat rendering fix

### DIFF
--- a/ionic.wheel.js
+++ b/ionic.wheel.js
@@ -1,100 +1,103 @@
 angular.module('ionic.wheel', [])
-  .directive('ionWheel', function($ionicGesture) {
+  .directive('ionWheel', function($ionicGesture, $timeout) {
 
     return {
       restrict: 'E',
       template: '<div id="ionic-wheel" ng-transclude></div>',
       transclude: true,
       link: function($scope, $element, $attr) {
+          
+        $timeout(function () {
+            /**
+             * Get elements
+             */
+            var circle = $element[0],
+                circles = document.getElementsByClassName('circle'),
+                circleDimensions = circle.getBoundingClientRect(),
+                transcludeDiv = document.getElementById('ionic-wheel'),
+                centerCircle = document.getElementById('activate');
 
-        /**
-         * Get elements
-         */
-        var circle = $element[0],
-            circles = document.getElementsByClassName('circle'),
-            circleDimensions = circle.getBoundingClientRect(),
-            transcludeDiv = document.getElementById('ionic-wheel'),
-            centerCircle = document.getElementById('activate');
+            /**
+             * Position circles around parent circle
+             */
 
-        /**
-         * Position circles around parent circle
-         */
+            var theta = [];
 
-        var theta = [];
+            var n = circles.length;
 
-        var n = circles.length;
+            var r = (window.getComputedStyle(transcludeDiv).height.slice(0, -2) / 2) - (window.getComputedStyle(circles[0]).height.slice(0, -2) / 2);
 
-        var r = (window.getComputedStyle(transcludeDiv).height.slice(0, -2) / 2) - (window.getComputedStyle(circles[0]).height.slice(0, -2) / 2);
+            var frags = 360 / n;
+            for (var i = 0; i <= n; i++) {
+                theta.push((frags / 180) * i * Math.PI);
+            }
 
-        var frags = 360 / n;
-        for (var i = 0; i <= n; i++) {
-            theta.push((frags / 180) * i * Math.PI);
-        }
+            var mainHeight = parseInt(window.getComputedStyle(transcludeDiv).height.slice(0, -2)) / 1.2;
 
-        var mainHeight = parseInt(window.getComputedStyle(transcludeDiv).height.slice(0, -2)) / 1.2;
+            var circleArray = [];
 
-        var circleArray = [];
+            for (var i = 0; i < circles.length; i++) {
+              circles[i].posx = Math.round(r * (Math.cos(theta[i]))) + 'px';
+              circles[i].posy = Math.round(r * (Math.sin(theta[i]))) + 'px';
+              circles[i].style.top = ((mainHeight / 2) - parseInt(circles[i].posy.slice(0, -2))) + 'px';
+              circles[i].style.left = ((mainHeight/ 2 ) + parseInt(circles[i].posx.slice(0, -2))) + 'px';
+            }
 
-        for (var i = 0; i < circles.length; i++) {
-          circles[i].posx = Math.round(r * (Math.cos(theta[i]))) + 'px';
-          circles[i].posy = Math.round(r * (Math.sin(theta[i]))) + 'px';
-          circles[i].style.top = ((mainHeight / 2) - parseInt(circles[i].posy.slice(0, -2))) + 'px';
-          circles[i].style.left = ((mainHeight/ 2 ) + parseInt(circles[i].posx.slice(0, -2))) + 'px';
-        }
+            /**
+             * Rotate circle on drag
+             */
 
-        /**
-         * Rotate circle on drag
-         */
+            var center = {
+              x: circleDimensions.left + circleDimensions.width / 2,
+              y: circleDimensions.top + circleDimensions.height / 2
+            };
 
-        var center = {
-          x: circleDimensions.left + circleDimensions.width / 2,
-          y: circleDimensions.top + circleDimensions.height / 2
-        };
+            var getAngle = function(x, y){
+              var deltaX = x - center.x,
+                  deltaY = y - center.y,
+                  angle = Math.atan2(deltaY, deltaX) * 180 / Math.PI;
 
-        var getAngle = function(x, y){
-          var deltaX = x - center.x,
-              deltaY = y - center.y,
-              angle = Math.atan2(deltaY, deltaX) * 180 / Math.PI;
+              if(angle < 0) {
+                angle = angle + 360;
+              }
 
-          if(angle < 0) {
-            angle = angle + 360;
-          }
+              return angle;
+            };
 
-          return angle;
-        };
+            var updatedAngle = 0,
+                originalAngle = 0,
+                currentAngle = 0;
 
-        var updatedAngle = 0,
-            originalAngle = 0,
-            currentAngle = 0;
+            $ionicGesture.on('dragstart', function(e){
+              var pageX = e.gesture.touches[0].pageX;
+              var pageY = e.gesture.touches[0].pageY;
+              updatedAngle = getAngle(pageX, pageY);
+            }, angular.element(circle));
 
-        $ionicGesture.on('dragstart', function(e){
-          var pageX = e.gesture.touches[0].pageX;
-          var pageY = e.gesture.touches[0].pageY;
-          updatedAngle = getAngle(pageX, pageY);
-        }, angular.element(circle));
+            $ionicGesture.on('drag', function(e){
 
-        $ionicGesture.on('drag', function(e){
+              e.gesture.srcEvent.preventDefault();
 
-          e.gesture.srcEvent.preventDefault();
+              var pageX = e.gesture.touches[0].pageX;
+              var pageY = e.gesture.touches[0].pageY;
 
-          var pageX = e.gesture.touches[0].pageX;
-          var pageY = e.gesture.touches[0].pageY;
+              currentAngle = getAngle(pageX, pageY) - updatedAngle + originalAngle;
 
-          currentAngle = getAngle(pageX, pageY) - updatedAngle + originalAngle;
+              circle.style.transform = circle.style.webkitTransform  = 'rotate(' + currentAngle + 'deg)';
 
-          circle.style.transform = circle.style.webkitTransform  = 'rotate(' + currentAngle + 'deg)';
+              for (var i = 0; i < circles.length; i++) {
+                circles[i].style.transform = circles[i].style.webkitTransform = 'rotate(' + -currentAngle + 'deg)';
+              }
 
-          for (var i = 0; i < circles.length; i++) {
-            circles[i].style.transform = circles[i].style.webkitTransform = 'rotate(' + -currentAngle + 'deg)';
-          }
+            }, angular.element(circle));
 
-        }, angular.element(circle));
+            $ionicGesture.on('dragend', function(e){
+              originalAngle = currentAngle;
+            }, angular.element(circle));
+        }, 0);
 
-        $ionicGesture.on('dragend', function(e){
-          originalAngle = currentAngle;
-        }, angular.element(circle));
 
       }
-    }
+    };
 
   });


### PR DESCRIPTION
When you `ng-repeat` child elements of the `ion-wheel` directive, `window.getComputedStyle` fails because ng-repeat has not finished rendering all of the DOM elements yet. This fix allows the directive to first finish rendering all of its DOM contents before proceeding with the styling logic for the entire carousel.
